### PR TITLE
Support Rails5

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,15 @@ unite-rails additional sources
 * unite /app/decorators
   + :Unite rails/decorator
 
-### Other
+### Rails 5
 
 * unite /app/jobs
   + :Unite rails/job
+* unite /app/channels
+  + :Unite rails/channel
+
+### Other
+
 * unite /app/validators
   + :Unite rails/validator
 

--- a/autoload/unite/sources/rails/collector/channel.vim
+++ b/autoload/unite/sources/rails/collector/channel.vim
@@ -1,0 +1,7 @@
+"
+" gather candidates
+"
+function! unite#sources#rails#collector#job#candidates(source)
+  let target = a:source.source__rails_root . '/app/channels'
+  return unite#sources#rails#helper#gather_candidates_file(target)
+endfunction

--- a/autoload/unite/sources/rails/collector/channel.vim
+++ b/autoload/unite/sources/rails/collector/channel.vim
@@ -1,7 +1,7 @@
 "
 " gather candidates
 "
-function! unite#sources#rails#collector#job#candidates(source)
+function! unite#sources#rails#collector#channel#candidates(source)
   let target = a:source.source__rails_root . '/app/channels'
   return unite#sources#rails#helper#gather_candidates_file(target)
 endfunction


### PR DESCRIPTION
* `:Unite rails/channel`を追加
* `:Unite rails/job`は以前から導入していたので、READMEの記載位置のみ変更

他に追加しなければならないものあったっけ
というか、これは basyura/unite-rails の方にPRした方が良いと思っている。